### PR TITLE
feat(QA): add sprint 5 validation and handoff docs

### DIFF
--- a/handoff/README_handoff.md
+++ b/handoff/README_handoff.md
@@ -1,0 +1,32 @@
+# Handoff Sprint 6
+
+## Objetivo
+
+Preparar los insumos mínimos necesarios para que el Sprint 6 pueda iniciar el despliegue del MVP del modelo.
+
+## Artefactos principales
+
+| Artefacto | Ubicación | Uso |
+|---|---|---|
+| Modelo final | `models/final_model.pkl` | Modelo utilizado para predicción. |
+| Dashboard | `dashboard/app.py` | Aplicación Streamlit para demo e interacción. |
+| Archivo de prueba | `X_test_sample.csv` | Archivo usado para validar carga y predicción. |
+| Dependencias | `requirements.txt` | Librerías necesarias para ejecutar la app. |
+| Validación QA | `reports/qa_validation.md` | Evidencia de pruebas realizadas. |
+| Feedback | `reports/feedback.md` | Observaciones del stakeholder/reviewer. |
+
+## Consideraciones para Sprint 6
+
+- Confirmar que el modelo final se carga correctamente desde `models/final_model.pkl`.
+- Validar que el archivo de entrada no requiera la variable objetivo `attrition`.
+- Mantener un esquema claro de columnas esperadas por el modelo.
+- Asegurar que `requirements.txt` contenga todas las librerías necesarias para ejecutar Streamlit.
+- Mantener mensaje de carga para la sección SHAP, ya que puede tardar algunos segundos.
+- Agregar explicación de negocio para predicción y probabilidad.
+- Documentar ejemplos de input/output para facilitar el despliegue del MVP.
+
+## Estado del handoff
+
+El dashboard se encuentra disponible para demo y las observaciones QA han sido documentadas.
+
+El paquete queda listo como base para el Sprint 6, sujeto a correcciones menores antes del despliegue final.

--- a/reports/feedback.md
+++ b/reports/feedback.md
@@ -1,0 +1,22 @@
+# Stakeholder Feedback - Sprint 5
+
+## Objetivo
+
+Registrar feedback funcional y de negocio sobre el dashboard y los entregables del Sprint 5, considerando la perspectiva de un stakeholder no técnico.
+
+## Feedback recibido
+
+| Aspecto evaluado | Comentario | Acción recomendada |
+|---|---|---|
+| Claridad del dashboard | El dashboard permite cargar datos y obtener predicciones de forma directa. | Mantener flujo simple para la demo. |
+| Interpretación de predicciones | No queda completamente claro qué representa la predicción 0/1. | Agregar leyenda: 0 = sin riesgo, 1 = riesgo de attrition. |
+| Probabilidad | La probabilidad se muestra, pero podría explicarse mejor. | Agregar texto: “Probabilidad estimada de pertenecer a la clase de riesgo”. |
+| Explicabilidad SHAP | SHAP carga correctamente y permite visualizar importancia global e individual. | Mantener la sección, pero conservar mensaje de carga porque puede tardar. |
+| Archivo de entrada | El CSV de prueba contiene la columna `attrition`. | Para producción, definir input sin target o aclarar que se ignora al predecir. |
+| Preparación para Sprint 6 | Se requiere dejar claro qué modelo y dependencias usar. | Preparar handoff con modelo, requirements y contratos de entrada/salida. |
+
+## Conclusión del feedback
+
+El dashboard es útil como prototipo de demostración para stakeholders, ya que permite cargar datos, visualizar predicciones y revisar explicabilidad mediante SHAP.
+
+Para mejorar su uso en despliegue, se recomienda reforzar la explicación de resultados, documentar el esquema de entrada y mantener control sobre las columnas requeridas por el modelo.

--- a/reports/qa_validation.md
+++ b/reports/qa_validation.md
@@ -1,0 +1,38 @@
+# QA Validation - Sprint 5
+
+## Objetivo
+
+Validar de extremo a extremo los principales entregables del Sprint 5: dashboard, consistencia funcional, accesibilidad para stakeholders y preparación del handoff hacia Sprint 6.
+
+## Dashboard validado
+
+Link de la app:
+
+https://dp261-g7-8jkzf4ugrefxjghvo8usy3.streamlit.app/
+
+Archivo de prueba utilizado:
+
+`X_test_sample.csv`
+
+## Checklist de validación
+
+| Criterio | Estado | Evidencia / Comentario |
+|---|---|---|
+| La app abre correctamente | Aprobado | El dashboard publicado en Streamlit carga correctamente. |
+| Permite subir un archivo CSV | Aprobado | Se cargó el archivo `X_test_sample.csv`. |
+| Muestra datos cargados | Aprobado | El dashboard muestra una vista previa de las primeras filas. |
+| Genera predicciones | Aprobado | Se muestran columnas de predicción y probabilidad. |
+| Presenta modelo final | Aprobado | El dashboard indica uso de Stacking Pipeline. |
+| Muestra sección de explicabilidad | Aprobado con observación | La sección SHAP carga correctamente, pero puede tardar algunos segundos. |
+| Muestra importancia global SHAP | Aprobado | Se visualiza un summary plot con importancia global de variables. |
+| Muestra explicación individual SHAP | Aprobado | Se visualiza un force plot para una instancia seleccionada. |
+| Lenguaje entendible para stakeholder | Parcial | Se recomienda agregar explicación breve de qué significa predicción 0/1 y probabilidad. |
+| Uso de archivo de prueba | Aprobado con observación | El archivo contiene `attrition`, por lo que debe aclararse si se usa solo como referencia o si el dashboard lo ignora al predecir. |
+
+## Resultado de QA
+
+El dashboard cumple con el flujo mínimo esperado para demostración: carga de CSV, visualización de datos, predicción, probabilidad y explicabilidad mediante SHAP.
+
+## Recomendación
+
+Se recomienda aprobar el dashboard para demo del Sprint 5, dejando documentadas las observaciones como mejoras previas al Sprint 6.


### PR DESCRIPTION
Se agregan documentos de validación QA, feedback funcional y handoff para Sprint 6.

Incluye:
- Validación del dashboard Streamlit.
- Feedback de stakeholder/reviewer.
- README de handoff para despliegue del MVP.