### PR TITLE
feat(SRE): add monitoring plan and runbook

### DIFF
--- a/monitoring/monitoring_plan.md
+++ b/monitoring/monitoring_plan.md
@@ -1,0 +1,45 @@
+# Monitoring Plan - Sprint 6
+
+## Objetivo
+
+Definir el plan básico de monitoreo para la API del MVP desplegada en AWS.
+
+## Componentes monitoreados
+
+| Componente | Qué se monitorea | Motivo |
+|---|---|---|
+| API FastAPI | Disponibilidad, errores y latencia | Confirmar que el servicio responde correctamente. |
+| Endpoint `/health` | Estado operativo | Validar si la API está viva. |
+| Endpoint `/version` | Versión del modelo/API | Asegurar trazabilidad del artefacto desplegado. |
+| Endpoint `/predict` | Predicciones, errores y tiempos de respuesta | Validar funcionamiento del núcleo del MVP. |
+| Instancia AWS | Estado, CPU, memoria y disponibilidad | Evitar caídas durante demo o uso. |
+| Dashboard | Conexión con API | Confirmar que el usuario final puede consumir predicciones. |
+
+## Métricas recomendadas
+
+| Métrica | Descripción | Umbral sugerido |
+|---|---|---|
+| Availability | Porcentaje de tiempo que la API responde | Mayor a 95% en demo |
+| Latency p95 | Tiempo de respuesta del 95% de requests | Menor a 2 segundos |
+| Error rate 5xx | Porcentaje de errores del servidor | Menor a 5% |
+| Error rate 4xx | Errores por request inválido o API Key incorrecta | Monitorear, no necesariamente incidente |
+| Throughput | Cantidad de requests por minuto | Referencial para uso del MVP |
+| CPU usage | Uso de CPU de la instancia AWS | Alerta si supera 80% sostenido |
+| Memory usage | Uso de memoria | Alerta si supera 80% sostenido |
+
+## Logs recomendados
+
+La API debería registrar logs estructurados con los siguientes campos:
+
+```json
+{
+  "timestamp": "2026-05-XXT00:00:00",
+  "endpoint": "/predict",
+  "method": "POST",
+  "status_code": 200,
+  "latency_ms": 120,
+  "model_version": "final_model",
+  "prediction_label": 0,
+  "prediction_probability": 0.18,
+  "error": null
+}

--- a/monitoring/runbook.md
+++ b/monitoring/runbook.md
@@ -1,0 +1,117 @@
+# Runbook Operativo - Sprint 6
+
+## Objetivo
+
+Definir acciones básicas ante incidentes operativos de la API desplegada en AWS.
+
+## Escenario 1: La API no responde
+
+### Síntoma
+
+La URL pública no carga o el endpoint `/health` no responde.
+
+### Validación
+
+1. Verificar si la instancia AWS sigue activa.
+2. Probar la URL base de la API.
+3. Probar `/health`.
+4. Revisar si el laboratorio AWS sigue encendido.
+
+### Acción recomendada
+
+- Reiniciar la instancia si el laboratorio sigue activo.
+- Volver a ejecutar la API con Uvicorn si el proceso se detuvo.
+- Si cambió la IP pública, actualizar la URL usada por el dashboard o documentación.
+
+---
+
+## Escenario 2: `/health` falla
+
+### Síntoma
+
+El endpoint `/health` no retorna estado `ok`.
+
+### Validación
+
+1. Confirmar que el servidor está encendido.
+2. Revisar si el puerto 8000 está disponible.
+3. Revisar logs de la API.
+
+### Acción recomendada
+
+- Reiniciar el servicio de la API.
+- Validar que FastAPI esté corriendo correctamente.
+- Confirmar que la ruta `/health` esté definida en `api/main.py`.
+
+---
+
+## Escenario 3: `/predict` retorna error
+
+### Síntoma
+
+La API no genera predicción o retorna error 4xx/5xx.
+
+### Validación
+
+1. Confirmar que se envía el header `X-API-Key`.
+2. Confirmar que el `Content-Type` sea `application/json`.
+3. Validar que el JSON tenga las columnas esperadas.
+4. Revisar si el modelo final está cargado correctamente.
+
+### Acción recomendada
+
+- Corregir el formato del request.
+- Confirmar que el modelo exista en la ruta esperada.
+- Revisar logs para identificar si el error es por input, API Key o modelo.
+
+---
+
+## Escenario 4: Latencia alta
+
+### Síntoma
+
+La API responde, pero demora demasiado.
+
+### Validación
+
+1. Medir tiempo de respuesta de `/predict`.
+2. Revisar si el cálculo del modelo o SHAP está demorando.
+3. Revisar consumo de CPU/memoria de la instancia.
+
+### Acción recomendada
+
+- Mantener SHAP fuera del flujo crítico de predicción si afecta la respuesta.
+- Revisar tamaño del input.
+- Considerar una instancia con mayores recursos si el MVP escala.
+
+---
+
+## Escenario 5: Dashboard no conecta con API
+
+### Síntoma
+
+El dashboard carga, pero no obtiene predicciones.
+
+### Validación
+
+1. Probar la API directamente en `/docs`.
+2. Confirmar que la URL de la API esté actualizada.
+3. Confirmar que la IP pública no haya cambiado.
+4. Confirmar que el puerto 8000 esté abierto.
+
+### Acción recomendada
+
+- Actualizar la URL base en el dashboard.
+- Confirmar que la instancia AWS esté activa.
+- Validar que la API Key esté correctamente configurada.
+
+---
+
+## Contacto y escalamiento
+
+Si el incidente no se resuelve:
+
+1. Avisar al Cloud / DevOps Engineer.
+2. Avisar al API Developer.
+3. Documentar el error, endpoint afectado y hora del incidente.
+4. Si aplica, usar la versión local como respaldo para la demo.

--- a/monitoring/sre_checklist.md
+++ b/monitoring/sre_checklist.md
@@ -1,0 +1,44 @@
+# SRE Checklist - Sprint 6
+
+## Objetivo
+
+Validar que la API desplegada para el MVP sea operable, monitoreable y segura a nivel básico antes de la demo.
+
+## Alcance
+
+Esta revisión se enfoca en la API desplegada en AWS y en sus endpoints principales:
+
+- `/health`
+- `/version`
+- `/docs`
+- `/predict`
+
+## Checklist operativo
+
+| Validación | Estado | Comentario |
+|---|---|---|
+| API accesible desde internet | Pendiente / Validar | Confirmar que la URL pública responda correctamente. |
+| Endpoint `/health` disponible | Pendiente / Validar | Debe retornar un estado simple como `{"status": "ok"}`. |
+| Endpoint `/version` disponible | Pendiente / Validar | Debe permitir verificar la versión del modelo o artefacto cargado. |
+| Swagger UI `/docs` disponible | Pendiente / Validar | Debe mostrar la documentación interactiva de FastAPI. |
+| Endpoint `/predict` disponible | Pendiente / Validar | Debe aceptar un JSON con datos de empleado y retornar predicción. |
+| API Key requerida | Pendiente / Validar | El endpoint `/predict` debe requerir header `X-API-Key`. |
+| Modelo final cargado | Pendiente / Validar | Confirmar que la API usa el modelo final definido por el equipo. |
+| Respuesta de predicción clara | Pendiente / Validar | Debe retornar probabilidad y etiqueta de riesgo. |
+| Logs básicos disponibles | Pendiente / Validar | Registrar fecha, endpoint, status code, latencia y error si ocurre. |
+| Manejo de errores | Pendiente / Validar | Si el input es inválido, la API debe responder con error controlado. |
+
+## Evidencia esperada
+
+Para considerar la API lista para demo, se debe poder validar:
+
+1. Abrir `/docs`.
+2. Ejecutar `/health`.
+3. Ejecutar `/version`.
+4. Ejecutar `/predict` con API Key.
+5. Ver una respuesta con probabilidad y label.
+6. Confirmar que no se exponen credenciales en GitHub.
+
+## Observación
+
+La API fue desplegada sobre una instancia AWS temporal. Dado que el laboratorio puede cerrarse después de algunas horas, se recomienda validar disponibilidad antes de la exposición.


### PR DESCRIPTION
Se agregan documentos para el rol Site Reliability & Monitoring del Sprint 6.

Incluye:
- Checklist operativo de endpoints /health, /version, /docs y /predict.
- Runbook ante incidentes de API, dashboard, latencia y modelo.
- Plan de monitoreo con métricas, logs, alertas y consideraciones AWS.